### PR TITLE
v2.0.0

### DIFF
--- a/general-cn/configuration.nix
+++ b/general-cn/configuration.nix
@@ -100,17 +100,7 @@
     jetbrains-mono
     texlivePackages.opensans
     inter-nerdfont
-    nerd-fonts.jetBrains-mono
-    nerd-fonts.zed-mono
-    nerd-fonts.symbols-only
-    nerd-fonts.terminless
-    nerd-fonts.ubuntu
-    nerd-fonts.ubuntu-mono
-    nerd-fonts.ubuntu-sans
-    nerd-fonts.victor-mono
-    nerd-fonts.noto
-    nerd-fonts.lilex
-    nerd-fonts.literation-mono
+    nerdfonts
     roboto
     roboto-mono
   ];

--- a/general/configuration.nix
+++ b/general/configuration.nix
@@ -95,17 +95,7 @@
     jetbrains-mono
     texlivePackages.opensans
     inter-nerdfont
-    nerd-fonts.jetBrains-mono
-    nerd-fonts.zed-mono
-    nerd-fonts.symbols-only
-    nerd-fonts.terminless
-    nerd-fonts.ubuntu
-    nerd-fonts.ubuntu-mono
-    nerd-fonts.ubuntu-sans
-    nerd-fonts.victor-mono
-    nerd-fonts.noto
-    nerd-fonts.lilex
-    nerd-fonts.literation-mono
+    nerdfonts
   ];
 
   nix.extraOptions = ''


### PR DESCRIPTION
Issue #1 as reference.
About the option definition of `nerdfonts`, the upstream support of `v2.0.0` branch is for NixOS 24.11 only. Since `v2.1.0-pre`, the old options will be deprecated and will be redirected to new options.